### PR TITLE
[feat] 사용자 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     ALREADY_EXIST_ACCOUNT(HttpStatus.CONFLICT, "이미 존재하는 계정명입니다."),
 
     // 로그인
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "계정명 또는 비밀번호를 확인해주세요. 회원가입하지 않았을 경우 회원가입을 진행해주세요.");
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "계정명 또는 비밀번호를 확인해주세요. 회원가입하지 않았을 경우 회원가입을 진행해주세요."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 
     // 회원가입
-    ALREADY_EXIST_ACCOUNT(HttpStatus.CONFLICT, "이미 존재하는 계정명입니다.");
+    ALREADY_EXIST_ACCOUNT(HttpStatus.CONFLICT, "이미 존재하는 계정명입니다."),
+
+    // 로그인
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "계정명 또는 비밀번호를 확인해주세요. 회원가입하지 않았을 경우 회원가입을 진행해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/finance/exception/NotFoundException.java
+++ b/src/main/java/com/finance/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.finance.exception;
+
+public class NotFoundException extends BaseException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/finance/exception/UnauthorizedException.java
+++ b/src/main/java/com/finance/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.finance.exception;
+
+public class UnauthorizedException extends BaseException {
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UnauthorizedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/finance/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/finance/exception/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.finance.exception.handler;
 import com.finance.exception.BadRequestException;
 import com.finance.exception.ConflictException;
 import com.finance.exception.ErrorResponse;
+import com.finance.exception.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -30,6 +31,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {
         return ResponseEntity.badRequest()
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
 

--- a/src/main/java/com/finance/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/finance/exception/handler/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.finance.exception.handler;
 
-import com.finance.exception.BadRequestException;
-import com.finance.exception.ConflictException;
-import com.finance.exception.ErrorResponse;
-import com.finance.exception.UnauthorizedException;
+import com.finance.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -37,6 +34,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
 

--- a/src/main/java/com/finance/user/config/SecurityConfig.java
+++ b/src/main/java/com/finance/user/config/SecurityConfig.java
@@ -3,17 +3,21 @@ package com.finance.user.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -28,7 +32,19 @@ public class SecurityConfig {
                 // 세션 미사용
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
-                        .anyRequest().permitAll()); // 어떤 사용자든 접근 가능
+                        .requestMatchers("/api/users/**").permitAll() // 어떤 사용자든 접근 가능
+                        .anyRequest().authenticated()) // 인증 필요
+                .exceptionHandling(e -> e
+                        // 인증 되지 않은 채로 인증 필요한 페이지 접근했을 경우
+                        .authenticationEntryPoint((request, response, exception) -> {
+                            response.sendError(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다.");
+                        })
+                        // 권한 없는데 권한이 필요한 페이지에 접근했을 경우
+                        .accessDeniedHandler((request, response, exception) -> {
+                            response.sendError(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.");
+                        }))
+                // 현재 필터를 UsernamePasswordAuthenticationFilter 앞에 위치시켜 토큰 인증 먼저 수행
+                .addFilterBefore(new TokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/finance/user/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/finance/user/config/TokenAuthenticationFilter.java
@@ -1,0 +1,32 @@
+package com.finance.user.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // Header에서 가져온 accessToken
+        String token = tokenProvider.resolveToken(request);
+        // accessToken 유효성 검증
+        if(token != null && tokenProvider.validToken(token)) {
+            // 인증 정보 담은 Authentication 객체
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            // 인증 정보를 보안 컨텍스트에 설정
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 응답과 요청을 다음 필터로 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/finance/user/config/TokenProvider.java
+++ b/src/main/java/com/finance/user/config/TokenProvider.java
@@ -1,0 +1,52 @@
+package com.finance.user.config;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+    @Value("${jwt.secret_key}")
+    private String key;
+    @Value("${jwt.access_token_expiration}")
+    private long accessTokenValidTime;
+    @Value("${jwt.refresh_token_expiration}")
+    private long refreshTokenValidTime;
+
+    // accessToken 생성
+    public String createAccessToken(String account) {
+        // 현재 시간
+        Date now = new Date();
+        // token 생성
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // 헤더 타입
+                .setClaims(Jwts.claims()
+                        .setSubject(account) // 내용 sub : account
+                        .setIssuedAt(now) // 내용 iat : 현재 시간
+                        .setExpiration(new Date(now.getTime() + accessTokenValidTime)) // 내용 exp : 만료 시간
+                )
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+    // refreshToken 생성 - 회원 정보 포함 X
+    public String createRefreshToken() {
+        // 현재 시간
+        Date now = new Date();
+        // token 생성
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(Jwts.claims()
+                        .setIssuedAt(now)
+                        .setExpiration(new Date(now.getTime() + refreshTokenValidTime))
+                )
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+}

--- a/src/main/java/com/finance/user/config/TokenProvider.java
+++ b/src/main/java/com/finance/user/config/TokenProvider.java
@@ -1,5 +1,7 @@
 package com.finance.user.config;
 
+import com.finance.user.domain.Token;
+import com.finance.user.repository.TokenRepository;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -8,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -18,6 +21,8 @@ public class TokenProvider {
     private long accessTokenValidTime;
     @Value("${jwt.refresh_token_expiration}")
     private long refreshTokenValidTime;
+
+    private final TokenRepository tokenRepository;
 
     // accessToken 생성
     public String createAccessToken(String account) {
@@ -36,17 +41,22 @@ public class TokenProvider {
     }
 
     // refreshToken 생성 - 회원 정보 포함 X
-    public String createRefreshToken() {
+    public String createRefreshToken(UUID userId) {
         // 현재 시간
         Date now = new Date();
         // token 생성
-        return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setClaims(Jwts.claims()
-                        .setIssuedAt(now)
-                        .setExpiration(new Date(now.getTime() + refreshTokenValidTime))
-                )
-                .signWith(SignatureAlgorithm.HS256, key)
-                .compact();
+        String refreshToken = Jwts.builder()
+                            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                            .setClaims(Jwts.claims()
+                                    .setIssuedAt(now)
+                                    .setExpiration(new Date(now.getTime() + refreshTokenValidTime))
+                            )
+                            .signWith(SignatureAlgorithm.HS256, key)
+                            .compact();
+        // token 객체 생성
+        Token token = new Token(refreshToken, userId, refreshTokenValidTime);
+        // redis 저장
+        tokenRepository.save(token);
+        return refreshToken;
     }
 }

--- a/src/main/java/com/finance/user/config/TokenProvider.java
+++ b/src/main/java/com/finance/user/config/TokenProvider.java
@@ -1,12 +1,18 @@
 package com.finance.user.config;
 
 import com.finance.user.domain.Token;
+import com.finance.user.domain.UserDetail;
 import com.finance.user.repository.TokenRepository;
+import com.finance.user.service.UserDetailService;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -22,7 +28,10 @@ public class TokenProvider {
     @Value("${jwt.refresh_token_expiration}")
     private long refreshTokenValidTime;
 
+    private final String BEARER_PREFIX = "Bearer ";
+
     private final TokenRepository tokenRepository;
+    private final UserDetailService userDetailService;
 
     // accessToken 생성
     public String createAccessToken(String account) {
@@ -58,5 +67,45 @@ public class TokenProvider {
         // redis 저장
         tokenRepository.save(token);
         return refreshToken;
+    }
+
+    // Header에서 토큰 가져오는 메서드
+    public String resolveToken(HttpServletRequest request) {
+        // Header의 Authorization 값 가져오기
+        String header = request.getHeader("Authorization");
+        // header 값이 null이 아니고 BEARER_PREFIX 값으로 시작하면 BEARER_PREFIX 이후의 값으로 반환
+        if(header != null && header.startsWith(BEARER_PREFIX))
+            return header.substring(BEARER_PREFIX.length());
+        return null;
+    }
+
+    // 토큰 유효성 검증
+    public boolean validToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(key) // 토큰 검증하는데 사용되는 서명키 설정
+                    .parseClaimsJws(token); // 토큰 파싱하고 서명 유효한지 확인
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // accessToken으로 인증 정보 담은 Authentication 반환
+    public Authentication getAuthentication(String token) {
+        UserDetail userDetail = (UserDetail) userDetailService.loadUserByUsername(getAccount(token));
+        return new UsernamePasswordAuthenticationToken(userDetail, "", userDetail.getAuthorities());
+        /* principal : 인증된 사용자 정보
+           credentials : 사용자의 인증 자격 증명 (인증 완료된 상태이므로 빈 문자열 사용)
+           authorities : 사용자의 권한목록 */
+    }
+
+    // accessToken에서 account 추출
+    public String getAccount(String token) {
+        try {
+            // JWT를 파싱해서 JWT 서명 검증 후 클레임을 반환하여 payload에서 subject 클레임 추출
+            return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        }
     }
 }

--- a/src/main/java/com/finance/user/config/TokenProvider.java
+++ b/src/main/java/com/finance/user/config/TokenProvider.java
@@ -63,7 +63,7 @@ public class TokenProvider {
                             .signWith(SignatureAlgorithm.HS256, key)
                             .compact();
         // token 객체 생성
-        Token token = new Token(refreshToken, userId, refreshTokenValidTime);
+        Token token = new Token(refreshToken, userId.toString(), refreshTokenValidTime);
         // redis 저장
         tokenRepository.save(token);
         return refreshToken;

--- a/src/main/java/com/finance/user/controller/UserController.java
+++ b/src/main/java/com/finance/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.finance.user.controller;
 
 import com.finance.user.dto.SignUpRequestDto;
 import com.finance.user.dto.SignUpResponseDto;
+import com.finance.user.dto.UserLoginRequestDto;
+import com.finance.user.dto.UserLoginResponseDto;
 import com.finance.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +25,12 @@ public class UserController {
     public ResponseEntity<SignUpResponseDto> signUp(@Valid @RequestBody SignUpRequestDto requestDto) {
         SignUpResponseDto responseDto = userService.signUp(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<UserLoginResponseDto> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
+        UserLoginResponseDto responseDto = userService.login(requestDto);
+        return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/finance/user/domain/Token.java
+++ b/src/main/java/com/finance/user/domain/Token.java
@@ -1,0 +1,22 @@
+package com.finance.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.UUID;
+
+@Getter
+@RedisHash("tokens")
+@AllArgsConstructor
+public class Token {
+    @Id
+    private String refreshToken;
+
+    private UUID userId;
+
+    @TimeToLive
+    private Long expiration;
+}

--- a/src/main/java/com/finance/user/domain/Token.java
+++ b/src/main/java/com/finance/user/domain/Token.java
@@ -15,7 +15,7 @@ public class Token {
     @Id
     private String refreshToken;
 
-    private UUID userId;
+    private String userId;
 
     @TimeToLive
     private Long expiration;

--- a/src/main/java/com/finance/user/domain/UserDetail.java
+++ b/src/main/java/com/finance/user/domain/UserDetail.java
@@ -1,0 +1,60 @@
+package com.finance.user.domain;
+
+import lombok.Builder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserDetail implements UserDetails {
+    private String account;
+    private String password;
+    private List<GrantedAuthority> authorities;
+
+    @Builder
+    public UserDetail(String account, String password, List<GrantedAuthority> authorities) {
+        this.account = account;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return account;
+    }
+
+    // 계정 만료 여부
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    // 계정 잠금 여부
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    // 비밀번호 만료 여부
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    // 계정 사용 가능 여부
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/finance/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/finance/user/dto/UserLoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.finance.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLoginRequestDto(
+        @NotBlank(message = "계정을 입력해주세요.") String account,
+        @NotBlank(message = "비밀번호를 입력해주세요.") String password
+) {
+}

--- a/src/main/java/com/finance/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/finance/user/dto/UserLoginResponseDto.java
@@ -1,0 +1,6 @@
+package com.finance.user.dto;
+
+public record UserLoginResponseDto(
+        String accessToken, String refreshToken
+) {
+}

--- a/src/main/java/com/finance/user/repository/TokenRepository.java
+++ b/src/main/java/com/finance/user/repository/TokenRepository.java
@@ -1,0 +1,7 @@
+package com.finance.user.repository;
+
+import com.finance.user.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenRepository extends CrudRepository<Token, String> {
+}

--- a/src/main/java/com/finance/user/service/UserDetailService.java
+++ b/src/main/java/com/finance/user/service/UserDetailService.java
@@ -1,0 +1,38 @@
+package com.finance.user.service;
+
+import com.finance.exception.ErrorCode;
+import com.finance.exception.NotFoundException;
+import com.finance.user.domain.User;
+import com.finance.user.domain.UserDetail;
+import com.finance.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByAccount(username)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+        List<GrantedAuthority> roles = new ArrayList<>();
+        roles.add(new SimpleGrantedAuthority(user.getRole().toString()));
+
+
+        return UserDetail.builder()
+                .account(user.getAccount())
+                .password(user.getPassword())
+                .authorities(roles)
+                .build();
+    }
+}

--- a/src/main/java/com/finance/user/service/UserService.java
+++ b/src/main/java/com/finance/user/service/UserService.java
@@ -2,20 +2,26 @@ package com.finance.user.service;
 
 import com.finance.exception.ConflictException;
 import com.finance.exception.ErrorCode;
+import com.finance.exception.UnauthorizedException;
+import com.finance.user.config.TokenProvider;
 import com.finance.user.domain.Role;
 import com.finance.user.domain.User;
 import com.finance.user.dto.SignUpRequestDto;
 import com.finance.user.dto.SignUpResponseDto;
+import com.finance.user.dto.UserLoginRequestDto;
+import com.finance.user.dto.UserLoginResponseDto;
 import com.finance.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
 
     // 회원가입
     public SignUpResponseDto signUp(SignUpRequestDto requestDto) {
@@ -34,5 +40,20 @@ public class UserService {
         userRepository.save(user);
         // responseDto 생성 및 반환
         return new SignUpResponseDto("회원가입이 완료되었습니다.", user.getAccount());
+    }
+
+    // 로그인
+    @Transactional
+    public UserLoginResponseDto login(UserLoginRequestDto requestDto) {
+        // account로 회원 조회
+        User user = userRepository.findByAccount(requestDto.account())
+                .orElseThrow(() -> new UnauthorizedException(ErrorCode.LOGIN_FAILED));
+        // password 일치여부
+        if(!passwordEncoder.matches(requestDto.password(), user.getPassword()))
+            throw new UnauthorizedException(ErrorCode.LOGIN_FAILED);
+        // refreshToken 발급 및 저장
+        String refreshToken = tokenProvider.createRefreshToken(user.getUserId());
+        // accessToken 발급 및 responseDto 반환
+        return new UserLoginResponseDto(tokenProvider.createAccessToken(requestDto.account()), refreshToken);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,8 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: update
+
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
## Issue
- #5 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/login -> dev

## 변경 사항
- refreshToken의 효율적인 관리를 위한 redis 의존성 추가
- refreshToken 저장 시 `userId` 자료형 `String` 타입으로 변경

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/users/login
```
- **Request Body**
```
{
    "account": "jiwon",
    "password": "1234"
}
```

### Response : 성공시
`200 OK`
```
{
    "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaXdvbiIsImlhdCI6MTcyNjc3MDMxMCwiZXhwIjoxNzI2NzczOTEwfQ.j6PeEpP9O320mfGi4V187cMuDyu3qcLoLBjwhAz4zNM",
    "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjY3NzAzMDksImV4cCI6MTcyNzM3NTEwOX0.vFteWrm8U-RnwzFt_b-h5HeC2BWW0T6pD1yMBOam524"
}
```

### Response : 실패시
- 계정명 또는 비밀번호를 입력하지 않았을 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "비밀번호를 입력해주세요."
}
```

- 계정명 또는 비밀번호를 잘못 입력했을 경우
`401 Unauthorized`
```
{
    "status": 401,
    "message": "계정명 또는 비밀번호를 확인해주세요. 회원가입하지 않았을 경우 회원가입을 진행해주세요."
}
```