### PR TITLE
[feat] 액세스 토큰 재발급 API

### DIFF
--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
 
     // 로그인
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "계정명 또는 비밀번호를 확인해주세요. 회원가입하지 않았을 경우 회원가입을 진행해주세요."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+
+    // jwt
+    INVALID_OR_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/finance/user/config/SecurityConfig.java
+++ b/src/main/java/com/finance/user/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/api/users/**").permitAll() // 어떤 사용자든 접근 가능
+                        .requestMatchers("/api/tokens/**").permitAll()
                         .anyRequest().authenticated()) // 인증 필요
                 .exceptionHandling(e -> e
                         // 인증 되지 않은 채로 인증 필요한 페이지 접근했을 경우

--- a/src/main/java/com/finance/user/config/TokenProvider.java
+++ b/src/main/java/com/finance/user/config/TokenProvider.java
@@ -63,7 +63,7 @@ public class TokenProvider {
                             .signWith(SignatureAlgorithm.HS256, key)
                             .compact();
         // token 객체 생성
-        Token token = new Token(refreshToken, userId.toString(), refreshTokenValidTime);
+        Token token = new Token(refreshToken, userId.toString(), refreshTokenValidTime / 1000);
         // redis 저장
         tokenRepository.save(token);
         return refreshToken;

--- a/src/main/java/com/finance/user/controller/TokenController.java
+++ b/src/main/java/com/finance/user/controller/TokenController.java
@@ -1,7 +1,13 @@
 package com.finance.user.controller;
 
+import com.finance.user.dto.TokenRequestDto;
+import com.finance.user.dto.TokenResponseDto;
 import com.finance.user.service.TokenService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TokenController {
     private final TokenService tokenService;
+
+    @PostMapping("/access-token")
+    public ResponseEntity<TokenResponseDto> createNewAccessToken(@RequestBody TokenRequestDto requestDto) {
+        TokenResponseDto responseDto = tokenService.createNewAccessToken(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/user/controller/TokenController.java
+++ b/src/main/java/com/finance/user/controller/TokenController.java
@@ -1,0 +1,13 @@
+package com.finance.user.controller;
+
+import com.finance.user.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tokens")
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+}

--- a/src/main/java/com/finance/user/dto/TokenRequestDto.java
+++ b/src/main/java/com/finance/user/dto/TokenRequestDto.java
@@ -1,6 +1,6 @@
 package com.finance.user.dto;
 
 public record TokenRequestDto(
-        String accessToken, String refreshToken
+        String refreshToken
 ) {
 }

--- a/src/main/java/com/finance/user/dto/TokenRequestDto.java
+++ b/src/main/java/com/finance/user/dto/TokenRequestDto.java
@@ -1,0 +1,6 @@
+package com.finance.user.dto;
+
+public record TokenRequestDto(
+        String accessToken, String refreshToken
+) {
+}

--- a/src/main/java/com/finance/user/dto/TokenResponseDto.java
+++ b/src/main/java/com/finance/user/dto/TokenResponseDto.java
@@ -1,0 +1,6 @@
+package com.finance.user.dto;
+
+public record TokenResponseDto(
+        String accessToken
+) {
+}

--- a/src/main/java/com/finance/user/service/TokenService.java
+++ b/src/main/java/com/finance/user/service/TokenService.java
@@ -12,4 +12,9 @@ public class TokenService {
     private final TokenRepository tokenRepository;
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
+
+    // accessToken 재발급
+    public void createNewAccessToken() {
+
+    }
 }

--- a/src/main/java/com/finance/user/service/TokenService.java
+++ b/src/main/java/com/finance/user/service/TokenService.java
@@ -1,10 +1,21 @@
 package com.finance.user.service;
 
+import com.finance.exception.ErrorCode;
+import com.finance.exception.NotFoundException;
+import com.finance.exception.UnauthorizedException;
 import com.finance.user.config.TokenProvider;
+import com.finance.user.domain.Token;
+import com.finance.user.domain.User;
+import com.finance.user.domain.UserDetail;
+import com.finance.user.dto.TokenRequestDto;
+import com.finance.user.dto.TokenResponseDto;
 import com.finance.user.repository.TokenRepository;
 import com.finance.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -14,7 +25,16 @@ public class TokenService {
     private final UserRepository userRepository;
 
     // accessToken 재발급
-    public void createNewAccessToken() {
-
+    public TokenResponseDto createNewAccessToken(TokenRequestDto requestDto) {
+        // 입력받은 refreshToken과 매치되는 refreshToken을 redis에서 가져오기
+        Token refreshToken = tokenRepository.findById(requestDto.refreshToken())
+                .orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_OR_EXPIRED_TOKEN));
+        // refreshToken의 userId로 회원 찾기
+        User user = userRepository.findById(UUID.fromString(refreshToken.getUserId()))
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+        // accessToken 재발급
+        String newAccessToken = tokenProvider.createAccessToken(user.getAccount());
+        // responseDto 반환
+        return new TokenResponseDto(newAccessToken);
     }
 }

--- a/src/main/java/com/finance/user/service/TokenService.java
+++ b/src/main/java/com/finance/user/service/TokenService.java
@@ -1,0 +1,15 @@
+package com.finance.user.service;
+
+import com.finance.user.config.TokenProvider;
+import com.finance.user.repository.TokenRepository;
+import com.finance.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final TokenRepository tokenRepository;
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+}


### PR DESCRIPTION
## Issue
- #7 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/create_accessToken -> dev

## 변경 사항
- redis에 저장된 refreshToken에 회원의 식별값이 value로 저장되었기 때문에 refreshToken으로 회원을 조회

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/tokens/access-token
```
- **Request Body**
```
{
    "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjY3NzAzMDksImV4cCI6MTcyNzM3NTEwOX0.vFteWrm8U-RnwzFt_b-h5HeC2BWW0T6pD1yMBOam524"
}
```

### Response : 성공시
`201 Created`
```
{
    "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaXdvbiIsImlhdCI6MTcyNjg0MDg2NywiZXhwIjoxNzI2ODQ0NDY3fQ.2Fm-HhMpBXHFxDwdkGmjV5zdVLwJ4W6HcfeylKmEvZg"
}
```

### Response : 실패시
- 존재하지 않거나 만료된 refreshToken인 경우
`401 Unauthorized`
```
{
    "status": 401,
    "message": "세션이 만료되었습니다. 다시 로그인해주세요."
}
```