### PR TITLE
[feat] 카테고리 생성 API

### DIFF
--- a/src/main/java/com/finance/FinanceApplication.java
+++ b/src/main/java/com/finance/FinanceApplication.java
@@ -2,7 +2,9 @@ package com.finance;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FinanceApplication {
 

--- a/src/main/java/com/finance/category/controller/CategoryController.java
+++ b/src/main/java/com/finance/category/controller/CategoryController.java
@@ -1,13 +1,24 @@
 package com.finance.category.controller;
 
+import com.finance.category.dto.CreateCategoryRequestDto;
+import com.finance.category.dto.CreateCategoryResponseDto;
 import com.finance.category.service.CategoryService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/categories")
 @RequiredArgsConstructor
 public class CategoryController {
     private final CategoryService categoryService;
+
+    // 카테고리 생성
+    @PostMapping
+    public ResponseEntity<CreateCategoryResponseDto> createCategory(@RequestHeader(value = "Authorization")String token, @Valid @RequestBody CreateCategoryRequestDto requestDto) {
+        CreateCategoryResponseDto responseDto = categoryService.createCategory(token, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/category/controller/CategoryController.java
+++ b/src/main/java/com/finance/category/controller/CategoryController.java
@@ -1,0 +1,13 @@
+package com.finance.category.controller;
+
+import com.finance.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+}

--- a/src/main/java/com/finance/category/domain/Category.java
+++ b/src/main/java/com/finance/category/domain/Category.java
@@ -1,5 +1,6 @@
 package com.finance.category.domain;
 
+import com.finance.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -32,4 +33,8 @@ public class Category {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/finance/category/domain/Category.java
+++ b/src/main/java/com/finance/category/domain/Category.java
@@ -35,6 +35,6 @@ public class Category {
     private LocalDateTime deletedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private User user;
 }

--- a/src/main/java/com/finance/category/domain/Category.java
+++ b/src/main/java/com/finance/category/domain/Category.java
@@ -1,0 +1,35 @@
+package com.finance.category.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long categoryId;
+
+    @Column(nullable = false)
+    private String categoryName;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/finance/category/dto/CreateCategoryRequestDto.java
+++ b/src/main/java/com/finance/category/dto/CreateCategoryRequestDto.java
@@ -1,0 +1,8 @@
+package com.finance.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCategoryRequestDto(
+        @NotBlank(message = "카테고리명을 입력해주세요.") String categoryName
+) {
+}

--- a/src/main/java/com/finance/category/dto/CreateCategoryResponseDto.java
+++ b/src/main/java/com/finance/category/dto/CreateCategoryResponseDto.java
@@ -1,0 +1,8 @@
+package com.finance.category.dto;
+
+import java.time.LocalDateTime;
+
+public record CreateCategoryResponseDto(
+        String message, LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/finance/category/repository/CategoryRepository.java
+++ b/src/main/java/com/finance/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.finance.category.repository;
+
+import com.finance.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/finance/category/repository/CategoryRepository.java
+++ b/src/main/java/com/finance/category/repository/CategoryRepository.java
@@ -2,6 +2,14 @@ package com.finance.category.repository;
 
 import com.finance.category.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    // 회원 식별값과 카테고리명으로 카테고리 조회
+    @Query("SELECT c FROM Category c WHERE (c.user IS NULL OR c.user.userId = :userId) AND c.categoryName = :categoryName AND c.deletedAt IS NULL")
+    Optional<Category> findByUser_UserIdAndCategoryName(@Param("userId") UUID userId, @Param("categoryName") String categoryName);
 }

--- a/src/main/java/com/finance/category/service/CategoryService.java
+++ b/src/main/java/com/finance/category/service/CategoryService.java
@@ -1,0 +1,11 @@
+package com.finance.category.service;
+
+import com.finance.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+}

--- a/src/main/java/com/finance/category/service/CategoryService.java
+++ b/src/main/java/com/finance/category/service/CategoryService.java
@@ -1,11 +1,51 @@
 package com.finance.category.service;
 
+import com.finance.category.domain.Category;
+import com.finance.category.dto.CreateCategoryRequestDto;
+import com.finance.category.dto.CreateCategoryResponseDto;
 import com.finance.category.repository.CategoryRepository;
+import com.finance.exception.ConflictException;
+import com.finance.exception.ErrorCode;
+import com.finance.exception.NotFoundException;
+import com.finance.exception.UnauthorizedException;
+import com.finance.user.config.TokenProvider;
+import com.finance.user.domain.User;
+import com.finance.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
     private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    // 카테고리 생성
+    @Transactional
+    public CreateCategoryResponseDto createCategory(String token, CreateCategoryRequestDto requestDto) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // 해당 회원이 만든 카테고리 또는 기본 카테고리에 똑같은 카테고리명이 존재하는 경우 error
+        if(categoryRepository.findByUser_UserIdAndCategoryName(user.getUserId(), requestDto.categoryName()).isPresent())
+            throw new ConflictException(ErrorCode.ALREADY_EXIST_CATEGORY);
+        // 카테고리 생성
+        Category category = Category.builder()
+                .categoryName(requestDto.categoryName())
+                .user(user)
+                .build();
+        // DB 저장
+        categoryRepository.save(category);
+        // responseDto 반환
+        return new CreateCategoryResponseDto(requestDto.categoryName() + "가 생성되었습니다!", category.getCreatedAt());
+    }
+
+    // accessToken에서 회원 정보 가져오기
+    public User getUserInfo(String token) {
+        String accessToken = token.split("Bearer ")[1];
+        String account = tokenProvider.getAccount(accessToken);
+        return userRepository.findByAccount(account)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -18,7 +18,10 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
     // jwt
-    INVALID_OR_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요.");
+    INVALID_OR_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요."),
+
+    // 카테고리
+    ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## Issue
- #9 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/create_category -> dev

## 변경 사항
- JWT 검증을 통해 회원만 접근 가능
- 생성 시 기본 카테고리 또는 회원이 기존에 만든 카테고리와 이름이 동일할 경우 생성 불가

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/categories
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```
- **Request Body**
```
{
    "categoryName" : "반려동물"
}
```

### Response : 성공시
`201 Created`
```
{
    "message": "반려동물가 생성되었습니다!",
    "createdAt": "2024-09-21T02:34:25.2150999"
}
```

### Response : 실패시
- 카테고리명을 입력하지 않았을 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "카테고리명을 입력해주세요."
}
```

- 이미 존재하는 카테고리명인 경우
`409 Conflict`
```
{
    "status": 409,
    "message": "이미 존재하는 카테고리입니다."
}
```