### PR TITLE
[feat] 카테고리 전체 조회 API

### DIFF
--- a/src/main/java/com/finance/category/controller/CategoryController.java
+++ b/src/main/java/com/finance/category/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.finance.category.controller;
 
+import com.finance.category.dto.CategoryListResponseDto;
 import com.finance.category.dto.CreateCategoryRequestDto;
 import com.finance.category.dto.CreateCategoryResponseDto;
 import com.finance.category.service.CategoryService;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/categories")
@@ -20,5 +23,12 @@ public class CategoryController {
     public ResponseEntity<CreateCategoryResponseDto> createCategory(@RequestHeader(value = "Authorization")String token, @Valid @RequestBody CreateCategoryRequestDto requestDto) {
         CreateCategoryResponseDto responseDto = categoryService.createCategory(token, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    // 카테고리 전체 조회
+    @GetMapping
+    public ResponseEntity<List<CategoryListResponseDto>> getCategoryList(@RequestHeader(value = "Authorization")String token) {
+        List<CategoryListResponseDto> responseDto = categoryService.getCategoryList(token);
+        return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/finance/category/dto/CategoryListResponseDto.java
+++ b/src/main/java/com/finance/category/dto/CategoryListResponseDto.java
@@ -1,0 +1,8 @@
+package com.finance.category.dto;
+
+import java.util.UUID;
+
+public record CategoryListResponseDto(
+        String categoryName, UUID userId
+) {
+}

--- a/src/main/java/com/finance/category/repository/CategoryRepository.java
+++ b/src/main/java/com/finance/category/repository/CategoryRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +13,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     // 회원 식별값과 카테고리명으로 카테고리 조회
     @Query("SELECT c FROM Category c WHERE (c.user IS NULL OR c.user.userId = :userId) AND c.categoryName = :categoryName AND c.deletedAt IS NULL")
     Optional<Category> findByUser_UserIdAndCategoryName(@Param("userId") UUID userId, @Param("categoryName") String categoryName);
+
+    // 회원 식별값으로 카테고리 전체 조회
+    @Query("SELECT c FROM Category c WHERE (c.user IS NULL OR c.user.userId = :userId) AND c.deletedAt IS NULL")
+    List<Category> findByUser_UserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/finance/category/service/CategoryService.java
+++ b/src/main/java/com/finance/category/service/CategoryService.java
@@ -1,6 +1,7 @@
 package com.finance.category.service;
 
 import com.finance.category.domain.Category;
+import com.finance.category.dto.CategoryListResponseDto;
 import com.finance.category.dto.CreateCategoryRequestDto;
 import com.finance.category.dto.CreateCategoryResponseDto;
 import com.finance.category.repository.CategoryRepository;
@@ -14,6 +15,9 @@ import com.finance.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +43,20 @@ public class CategoryService {
         categoryRepository.save(category);
         // responseDto 반환
         return new CreateCategoryResponseDto(requestDto.categoryName() + "가 생성되었습니다!", category.getCreatedAt());
+    }
+
+    // 카테고리 전체 조회
+    public List<CategoryListResponseDto> getCategoryList(String token) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // 해당 회원이 만든 카테고리와 기본 카테고리 모두 조회
+        List<Category> categoryList = categoryRepository.findByUser_UserId(user.getUserId());
+        // responsedto로 변환
+        List<CategoryListResponseDto> responseDto = categoryList.stream()
+                .map(list -> new CategoryListResponseDto(list.getCategoryName(), list.getUser().getUserId()))
+                .collect(Collectors.toList());
+        // responsedto 반환
+        return responseDto;
     }
 
     // accessToken에서 회원 정보 가져오기

--- a/src/main/java/com/finance/category/service/CategoryService.java
+++ b/src/main/java/com/finance/category/service/CategoryService.java
@@ -51,9 +51,11 @@ public class CategoryService {
         User user = getUserInfo(token);
         // 해당 회원이 만든 카테고리와 기본 카테고리 모두 조회
         List<Category> categoryList = categoryRepository.findByUser_UserId(user.getUserId());
-        // responsedto로 변환
+        // responsedto로 변환 - user가 null인 카테고리는 기본 카테고리이므로 null 처리
         List<CategoryListResponseDto> responseDto = categoryList.stream()
-                .map(list -> new CategoryListResponseDto(list.getCategoryName(), list.getUser().getUserId()))
+                .map(list -> new CategoryListResponseDto(
+                        list.getCategoryName(),
+                        list.getUser() != null ? list.getUser().getUserId() : null))
                 .collect(Collectors.toList());
         // responsedto 반환
         return responseDto;


### PR DESCRIPTION
## Issue
- #11 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/category_list -> dev

## 변경 사항
- 기본 카테고리와 회원이 만든 카테고리 전체 조회
- 기본 카테고리의 경우 `user` 필드가 `null`로 저장되어있어 조회시 `null`에 대한 처리 추가

## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/categories
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```

### Response : 성공시
`200 OK`
```
[
    {
        "categoryName": "식비",
        "userId": null
    },
    {
        "categoryName": "교통",
        "userId": null
    },
    {
        "categoryName": "주거/통신",
        "userId": null
    },
    {
        "categoryName": "카페/간식",
        "userId": null
    },
    {
        "categoryName": "쇼핑",
        "userId": null
    },
    {
        "categoryName": "문화/여가",
        "userId": null
    },
    {
        "categoryName": "여행",
        "userId": null
    },
    {
        "categoryName": "의료",
        "userId": null
    },
    {
        "categoryName": "생활",
        "userId": null
    },
    {
        "categoryName": "교육",
        "userId": null
    },
    {
        "categoryName": "금융",
        "userId": null
    },
    {
        "categoryName": "반려동물",
        "userId": "286544b9-b963-41c8-a05b-d59670bceacc"
    }
]
```
