### PR TITLE
[feat] 카테고리 삭제 API

### DIFF
--- a/src/main/java/com/finance/category/controller/CategoryController.java
+++ b/src/main/java/com/finance/category/controller/CategoryController.java
@@ -36,4 +36,11 @@ public class CategoryController {
         ModifyCategoryResponseDto responseDto = categoryService.modifyCategory(categoryId, token, requestDto);
         return ResponseEntity.ok().body(responseDto);
     }
+
+    // 카테고리 삭제
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<DeleteCategoryResponseDto> deleteCategory(@PathVariable Long categoryId, @RequestHeader(value = "Authorization") String token) {
+        DeleteCategoryResponseDto responseDto = categoryService.deleteCategory(categoryId, token);
+        return ResponseEntity.ok().body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/category/domain/Category.java
+++ b/src/main/java/com/finance/category/domain/Category.java
@@ -42,4 +42,9 @@ public class Category {
         this.categoryName = categoryName;
         return this;
     }
+
+    public Category deleteCategory() {
+        this.deletedAt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/src/main/java/com/finance/category/dto/DeleteCategoryResponseDto.java
+++ b/src/main/java/com/finance/category/dto/DeleteCategoryResponseDto.java
@@ -1,0 +1,8 @@
+package com.finance.category.dto;
+
+import java.time.LocalDateTime;
+
+public record DeleteCategoryResponseDto(
+        String message, LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/com/finance/category/repository/CategoryRepository.java
+++ b/src/main/java/com/finance/category/repository/CategoryRepository.java
@@ -19,5 +19,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByUser_UserId(@Param("userId") UUID userId);
 
     // 카테고리 식별값으로 카테고리 찾기
+    @Query("SELECT c FROM Category c WHERE c.categoryId = :categoryId AND c.deletedAt IS NULL")
     Optional<Category> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/finance/category/service/CategoryService.java
+++ b/src/main/java/com/finance/category/service/CategoryService.java
@@ -75,6 +75,23 @@ public class CategoryService {
         return new ModifyCategoryResponseDto("카테고리명이 " + requestDto.categoryName() + "로 수정되었습니다.", category.getUpdatedAt());
     }
 
+    // 카테고리 삭제
+    @Transactional
+    public DeleteCategoryResponseDto deleteCategory(Long categoryId, String token) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // categoryId로 category 찾기
+        Category category = categoryRepository.findByCategoryId(categoryId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
+        // 회원 본인이 만든 카테고리가 아닌 경우 삭제 불가
+        if(category.getUser() == null || !user.getUserId().equals(category.getUser().getUserId()))
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        // 카테고리 삭제 - 예산, 지출과의 연결로 인한 논리 삭제
+        category.deleteCategory();
+        // responseDto 반환
+        return new DeleteCategoryResponseDto("카테고리 " + category.getCategoryName() + "가 삭제되었습니다.", category.getDeletedAt());
+    }
+
     // accessToken에서 회원 정보 가져오기
     public User getUserInfo(String token) {
         String accessToken = token.split("Bearer ")[1];


### PR DESCRIPTION
## Issue
- #15 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/delete_category -> dev

## 변경 사항
- 회원 본인이 만든 카테고리를 삭제하는 API
- 카테고리 식별값으로 카테고리를 조회할 때 삭제된 카테고리는 조회되지 않도록 수정

## 테스트 결과

### Request
```java
HTTP : DELETE
URL: /api/categories/:categoryId
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```

### Response : 성공시
`200 OK`
```
{
    "message": "카테고리 뽀삐가 삭제되었습니다.",
    "deletedAt": "2024-09-22T22:30:18.1640144"
}
```

### Response : 실패시
- 잘못된 `categoryId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 카테고리입니다."
}
```

- 회원 본인이 만든 카테고리가 아닌 경우
`403 Forbidden`
```
{
    "status": 403,
    "message": "접근 권한이 없습니다."
}
```