### PR TITLE
[feat] 예산 설정 API

### DIFF
--- a/src/main/java/com/finance/budget/controller/BudgetController.java
+++ b/src/main/java/com/finance/budget/controller/BudgetController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/budgets")
 @RequiredArgsConstructor
@@ -17,8 +19,8 @@ public class BudgetController {
 
     // 예산 설정
     @PostMapping
-    public ResponseEntity<CreateBudgetResponseDto> createBudget(@RequestHeader(value = "Authorization") String token, @Valid @RequestBody CreateBudgetRequestDto requestDto) {
-        CreateBudgetResponseDto responseDto = budgetService.createBudget(token, requestDto);
+    public ResponseEntity<List<CreateBudgetResponseDto>> createBudget(@RequestHeader(value = "Authorization") String token, @Valid @RequestBody List<CreateBudgetRequestDto> requestDto) {
+        List<CreateBudgetResponseDto> responseDto = budgetService.createBudget(token, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 }

--- a/src/main/java/com/finance/budget/controller/BudgetController.java
+++ b/src/main/java/com/finance/budget/controller/BudgetController.java
@@ -1,0 +1,13 @@
+package com.finance.budget.controller;
+
+import com.finance.budget.service.BudgetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/budgets")
+@RequiredArgsConstructor
+public class BudgetController {
+    private final BudgetService budgetService;
+}

--- a/src/main/java/com/finance/budget/controller/BudgetController.java
+++ b/src/main/java/com/finance/budget/controller/BudgetController.java
@@ -1,13 +1,24 @@
 package com.finance.budget.controller;
 
+import com.finance.budget.dto.CreateBudgetRequestDto;
+import com.finance.budget.dto.CreateBudgetResponseDto;
 import com.finance.budget.service.BudgetService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/budgets")
 @RequiredArgsConstructor
 public class BudgetController {
     private final BudgetService budgetService;
+
+    // 예산 설정
+    @PostMapping
+    public ResponseEntity<CreateBudgetResponseDto> createBudget(@RequestHeader(value = "Authorization") String token, @Valid @RequestBody CreateBudgetRequestDto requestDto) {
+        CreateBudgetResponseDto responseDto = budgetService.createBudget(token, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/budget/domain/Budget.java
+++ b/src/main/java/com/finance/budget/domain/Budget.java
@@ -1,0 +1,45 @@
+package com.finance.budget.domain;
+
+import com.finance.category.domain.Category;
+import com.finance.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "budgets")
+public class Budget {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long budgetId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+}

--- a/src/main/java/com/finance/budget/dto/CreateBudgetRequestDto.java
+++ b/src/main/java/com/finance/budget/dto/CreateBudgetRequestDto.java
@@ -1,0 +1,10 @@
+package com.finance.budget.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateBudgetRequestDto(
+        @NotNull(message = "카테고리는 필수로 지정해야 합니다.") Long categoryId,
+        @NotNull(message = "예산 금액은 필수로 지정해야 합니다.") @Positive(message = "입력한 값을 다시 확인해주세요.") Long amount
+) {
+}

--- a/src/main/java/com/finance/budget/dto/CreateBudgetResponseDto.java
+++ b/src/main/java/com/finance/budget/dto/CreateBudgetResponseDto.java
@@ -1,0 +1,8 @@
+package com.finance.budget.dto;
+
+import java.time.LocalDateTime;
+
+public record CreateBudgetResponseDto(
+        String categoryName, Long amount, LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/finance/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/finance/budget/repository/BudgetRepository.java
@@ -2,6 +2,14 @@ package com.finance.budget.repository;
 
 import com.finance.budget.domain.Budget;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
+    // 카테고리 식별값과 회원 식별값으로 예산 조회
+    @Query("SELECT b FROM Budget b WHERE b.user.userId = :userId AND b.category.categoryId = :categoryId AND b.deletedAt IS NULL")
+    Optional<Budget> findByCategory_CategoryIdAndUser_UserId(@Param("userId") UUID userId, @Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/finance/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/finance/budget/repository/BudgetRepository.java
@@ -1,0 +1,7 @@
+package com.finance.budget.repository;
+
+import com.finance.budget.domain.Budget;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetRepository extends JpaRepository<Budget, Long> {
+}

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -1,0 +1,11 @@
+package com.finance.budget.service;
+
+import com.finance.budget.repository.BudgetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetService {
+    private final BudgetRepository budgetRepository;
+}

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class BudgetService {
@@ -26,25 +29,31 @@ public class BudgetService {
 
     // 예산 설정
     @Transactional
-    public CreateBudgetResponseDto createBudget(String token, CreateBudgetRequestDto requestDto) {
+    public List<CreateBudgetResponseDto> createBudget(String token, List<CreateBudgetRequestDto> requestDtoList) {
         // accessToken에서 회원 정보 가져오기
         User user = getUserInfo(token);
-        // categoryId로 category 찾기
-        Category category = categoryRepository.findByCategoryId(requestDto.categoryId())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
-        // 이미 입력한 카테고리의 예산이 설정된 경우
-        if(budgetRepository.findByCategory_CategoryIdAndUser_UserId(user.getUserId(), requestDto.categoryId()).isPresent())
-            throw new ConflictException(ErrorCode.ALREADY_EXIST_BUDGET);
-        // 예산 생성
-        Budget budget = Budget.builder()
-                .amount(requestDto.amount())
-                .user(user)
-                .category(category)
-                .build();
-        // DB 저장
-        budgetRepository.save(budget);
+        // responseDto 생성
+        List<CreateBudgetResponseDto> responseDto = new ArrayList<>();
+        for(CreateBudgetRequestDto requestDto : requestDtoList) {
+            // categoryId로 category 찾기
+            Category category = categoryRepository.findByCategoryId(requestDto.categoryId())
+                    .orElseThrow(() -> new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
+            // 이미 입력한 카테고리의 예산이 설정된 경우
+            if(budgetRepository.findByCategory_CategoryIdAndUser_UserId(user.getUserId(), requestDto.categoryId()).isPresent())
+                throw new ConflictException(ErrorCode.ALREADY_EXIST_BUDGET);
+            // 예산 생성
+            Budget budget = Budget.builder()
+                    .amount(requestDto.amount())
+                    .user(user)
+                    .category(category)
+                    .build();
+            // DB 저장
+            budgetRepository.save(budget);
+            // responseDto에 추가
+            responseDto.add(new CreateBudgetResponseDto(category.getCategoryName(), requestDto.amount(), budget.getCreatedAt()));
+        }
         // responseDto 반환
-        return new CreateBudgetResponseDto(category.getCategoryName(), requestDto.amount(), budget.getCreatedAt());
+        return responseDto;
     }
 
     // accessToken에서 회원 정보 가져오기

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -1,11 +1,57 @@
 package com.finance.budget.service;
 
+import com.finance.budget.domain.Budget;
+import com.finance.budget.dto.CreateBudgetRequestDto;
+import com.finance.budget.dto.CreateBudgetResponseDto;
 import com.finance.budget.repository.BudgetRepository;
+import com.finance.category.domain.Category;
+import com.finance.category.repository.CategoryRepository;
+import com.finance.exception.ConflictException;
+import com.finance.exception.ErrorCode;
+import com.finance.exception.NotFoundException;
+import com.finance.user.config.TokenProvider;
+import com.finance.user.domain.User;
+import com.finance.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BudgetService {
     private final BudgetRepository budgetRepository;
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    // 예산 설정
+    @Transactional
+    public CreateBudgetResponseDto createBudget(String token, CreateBudgetRequestDto requestDto) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // categoryId로 category 찾기
+        Category category = categoryRepository.findByCategoryId(requestDto.categoryId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
+        // 이미 입력한 카테고리의 예산이 설정된 경우
+        if(budgetRepository.findByCategory_CategoryIdAndUser_UserId(user.getUserId(), requestDto.categoryId()).isPresent())
+            throw new ConflictException(ErrorCode.ALREADY_EXIST_BUDGET);
+        // 예산 생성
+        Budget budget = Budget.builder()
+                .amount(requestDto.amount())
+                .user(user)
+                .category(category)
+                .build();
+        // DB 저장
+        budgetRepository.save(budget);
+        // responseDto 반환
+        return new CreateBudgetResponseDto(category.getCategoryName(), requestDto.amount(), budget.getCreatedAt());
+    }
+
+    // accessToken에서 회원 정보 가져오기
+    public User getUserInfo(String token) {
+        String accessToken = token.split("Bearer ")[1];
+        String account = tokenProvider.getAccount(accessToken);
+        return userRepository.findByAccount(account)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
 
     // 카테고리
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리입니다."),
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다.");
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+
+    // 예산
+    ALREADY_EXIST_BUDGET(HttpStatus.CONFLICT, "해당 카테고리의 예산이 이미 존재합니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## Issue
- #17 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/create_budget -> dev

## 변경 사항
- 카테고리 별로 예산 설정
- 한 번에 여러 카테고리의 예산 설정을 위해 List형식으로 요청받음

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/budgets
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```
- **Request Body**
```
[
    {
        "categoryId": 1,
        "amount": 500000
    },
    {
        "categoryId": 2,
        "amount": 50000
    }
]
```

### Response : 성공시
`201 Created`
```
[
    {
        "categoryName": "식비",
        "amount": 500000,
        "createdAt": "2024-09-23T02:49:34.4954136"
    },
    {
        "categoryName": "교통",
        "amount": 50000,
        "createdAt": "2024-09-23T02:49:34.5357653"
    }
]
```

### Response : 실패시
- 잘못된 `categoryId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 카테고리입니다."
}
```

- 이미 입력한 카테고리의 예산이 설정된 경우
`409 Conflict`
```
{
    "status": 409,
    "message": "해당 카테고리의 예산이 이미 존재합니다."
}
```