### PR TITLE
[feat] 예산 삭제 API

### DIFF
--- a/src/main/java/com/finance/budget/controller/BudgetController.java
+++ b/src/main/java/com/finance/budget/controller/BudgetController.java
@@ -1,9 +1,6 @@
 package com.finance.budget.controller;
 
-import com.finance.budget.dto.BudgetListResponseDto;
-import com.finance.budget.dto.CreateBudgetRequestDto;
-import com.finance.budget.dto.CreateBudgetResponseDto;
-import com.finance.budget.dto.ModifyBudgetRequestDto;
+import com.finance.budget.dto.*;
 import com.finance.budget.service.BudgetService;
 import com.finance.category.dto.ModifyBudgetResponseDto;
 import jakarta.validation.Valid;
@@ -38,6 +35,13 @@ public class BudgetController {
     @PatchMapping("/{budgetId}")
     public ResponseEntity<ModifyBudgetResponseDto> modifyBudget(@PathVariable Long budgetId, @RequestHeader(value = "Authorization") String token, @Valid @RequestBody ModifyBudgetRequestDto requestDto) {
         ModifyBudgetResponseDto responseDto = budgetService.modifyBudget(budgetId, token, requestDto);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    // 예산 삭제
+    @DeleteMapping("/{budgetId}")
+    public ResponseEntity<DeleteBudgetResponseDto> deleteBudget(@PathVariable Long budgetId, @RequestHeader(value = "Authorization") String token) {
+        DeleteBudgetResponseDto responseDto = budgetService.deleteBudget(budgetId, token);
         return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/finance/budget/domain/Budget.java
+++ b/src/main/java/com/finance/budget/domain/Budget.java
@@ -47,4 +47,9 @@ public class Budget {
         this.amount = amount;
         return this;
     }
+
+    public Budget deleteBudget() {
+        this.deletedAt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/src/main/java/com/finance/budget/dto/DeleteBudgetResponseDto.java
+++ b/src/main/java/com/finance/budget/dto/DeleteBudgetResponseDto.java
@@ -1,0 +1,8 @@
+package com.finance.budget.dto;
+
+import java.time.LocalDateTime;
+
+public record DeleteBudgetResponseDto(
+        String message, LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -1,10 +1,7 @@
 package com.finance.budget.service;
 
 import com.finance.budget.domain.Budget;
-import com.finance.budget.dto.BudgetListResponseDto;
-import com.finance.budget.dto.CreateBudgetRequestDto;
-import com.finance.budget.dto.CreateBudgetResponseDto;
-import com.finance.budget.dto.ModifyBudgetRequestDto;
+import com.finance.budget.dto.*;
 import com.finance.budget.repository.BudgetRepository;
 import com.finance.category.domain.Category;
 import com.finance.category.dto.ModifyBudgetResponseDto;
@@ -93,6 +90,23 @@ public class BudgetService {
         budget.modifyBudget(requestDto.amount());
         // responseDto 반환
         return new ModifyBudgetResponseDto("예산 금액이 " + requestDto.amount() + "원으로 수정되었습니다.", budget.getUpdatedAt());
+    }
+
+    // 예산 삭제
+    @Transactional
+    public DeleteBudgetResponseDto deleteBudget(Long budgetId, String token) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // budgetId로 budget 찾기
+        Budget budget = budgetRepository.findByBudgetId(budgetId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.BUDGET_NOT_FOUND));
+        // 회원 본인이 만든 예산이 아닌 경우 삭제 불가
+        if(!user.getUserId().equals(budget.getUser().getUserId()))
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        // 예산 삭제 - 논리 삭제
+        budget.deleteBudget();
+        // responseDto 반환
+        return new DeleteBudgetResponseDto(budget.getCategory().getCategoryName() + "의 예산이 삭제되었습니다.", budget.getDeletedAt());
     }
 
     // accessToken에서 회원 정보 가져오기


### PR DESCRIPTION
## Issue
- #23 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/delete_budget -> dev

## 변경 사항
- 회원 본인이 만든 예산을 삭제하는 API

## 테스트 결과

### Request
```java
HTTP : DELETE
URL: /api/budgets/:budgetId
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```

### Response : 성공시
`200 OK`
```
{
    "message": "여행의 예산이 삭제되었습니다.",
    "deletedAt": "2024-09-23T15:52:08.2781597"
}
```

### Response : 실패시
- 잘못된 `budgetId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 예산입니다."
}
```

- 회원 본인이 만든 예산이 아닌 경우
`403 Forbidden`
```
{
    "status": 403,
    "message": "접근 권한이 없습니다."
}
```