### PR TITLE
[feat] 예산 추천 API

### DIFF
--- a/src/main/java/com/finance/budget/controller/BudgetController.java
+++ b/src/main/java/com/finance/budget/controller/BudgetController.java
@@ -44,4 +44,11 @@ public class BudgetController {
         DeleteBudgetResponseDto responseDto = budgetService.deleteBudget(budgetId, token);
         return ResponseEntity.ok().body(responseDto);
     }
+
+    // 예산 추천
+    @GetMapping("/recommendation")
+    public ResponseEntity<List<RecommendBudgetResponseDto>> recommendBudget(@Valid @RequestBody RecommendBudgetRequestDto requestDto) {
+        List<RecommendBudgetResponseDto> response = budgetService.recommendBudget(requestDto);
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/com/finance/budget/controller/BudgetController.java
+++ b/src/main/java/com/finance/budget/controller/BudgetController.java
@@ -2,7 +2,7 @@ package com.finance.budget.controller;
 
 import com.finance.budget.dto.*;
 import com.finance.budget.service.BudgetService;
-import com.finance.category.dto.ModifyBudgetResponseDto;
+import com.finance.budget.dto.ModifyBudgetResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/finance/budget/dto/BudgetRatioDto.java
+++ b/src/main/java/com/finance/budget/dto/BudgetRatioDto.java
@@ -1,0 +1,6 @@
+package com.finance.budget.dto;
+
+public record BudgetRatioDto(
+        String categoryName, double amountRatio
+) {
+}

--- a/src/main/java/com/finance/budget/dto/ModifyBudgetResponseDto.java
+++ b/src/main/java/com/finance/budget/dto/ModifyBudgetResponseDto.java
@@ -1,4 +1,4 @@
-package com.finance.category.dto;
+package com.finance.budget.dto;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/finance/budget/dto/RecommendBudgetRequestDto.java
+++ b/src/main/java/com/finance/budget/dto/RecommendBudgetRequestDto.java
@@ -1,0 +1,9 @@
+package com.finance.budget.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record RecommendBudgetRequestDto(
+        @NotNull(message = "예산 총 금액을 입력해주세요.") @Positive(message = "1원부터 입력 가능합니다.") Long totalAmount
+) {
+}

--- a/src/main/java/com/finance/budget/dto/RecommendBudgetResponseDto.java
+++ b/src/main/java/com/finance/budget/dto/RecommendBudgetResponseDto.java
@@ -1,0 +1,6 @@
+package com.finance.budget.dto;
+
+public record RecommendBudgetResponseDto(
+        String categoryName, Long amount
+) {
+}

--- a/src/main/java/com/finance/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/finance/budget/repository/BudgetRepository.java
@@ -1,6 +1,7 @@
 package com.finance.budget.repository;
 
 import com.finance.budget.domain.Budget;
+import com.finance.budget.dto.BudgetRatioDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +22,21 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     // 예산 식별값으로 예산 찾기
     @Query("SELECT b FROM Budget b WHERE b.budgetId = :budgetId AND b.deletedAt IS NULL")
     Optional<Budget> findByBudgetId(@Param("budgetId") Long budgetId);
+
+    // 예산 총액이 일정 범위 안에 있는 회원들의 기본 카테고리별 평균 비율 반환
+    @Query("SELECT new com.finance.budget.dto.BudgetRatioDto(c.categoryName, " +
+            "CAST((SUM(b.amount) * 1.0) / SUM(SUM(b.amount)) OVER() AS DOUBLE)) " +
+            "FROM Budget b " +
+            "JOIN Category c ON b.category.categoryId = c.categoryId " +
+            "WHERE c.user.userId IS NULL " +
+            "AND b.deletedAt IS NULL " +
+            "AND b.user.userId IN (" +
+                    "SELECT b2.user.userId "+
+                    "FROM Budget b2 " +
+                    "JOIN Category c2 ON b2.category.categoryId = c2.categoryId " +
+                    "WHERE b2.deletedAt IS NULL AND c2.user.userId IS NULL " +
+                    "GROUP BY b2.user.userId " +
+                    "HAVING SUM(b2.amount) BETWEEN :minAmount AND :maxAmount) " +
+            "GROUP BY b.category.categoryId")
+    List<BudgetRatioDto> findBudgetRatioByTotalAmountRange(@Param("minAmount") Long minAmount, @Param("maxAmount") Long maxAmount);
 }

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -4,7 +4,7 @@ import com.finance.budget.domain.Budget;
 import com.finance.budget.dto.*;
 import com.finance.budget.repository.BudgetRepository;
 import com.finance.category.domain.Category;
-import com.finance.category.dto.ModifyBudgetResponseDto;
+import com.finance.budget.dto.ModifyBudgetResponseDto;
 import com.finance.category.repository.CategoryRepository;
 import com.finance.exception.ConflictException;
 import com.finance.exception.ErrorCode;

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -124,7 +124,7 @@ public class BudgetService {
         for (BudgetRatioDto ratio : budgetRatioDto) {
             // 예산 평균 비율이 0.05 이상인 경우
             if(ratio.amountRatio() >= 0.05) {
-                Long recommendAmount = Math.round((requestDto.totalAmount() * ratio.amountRatio()) / 10.0) * 10;
+                Long recommendAmount = Math.round((requestDto.totalAmount() * ratio.amountRatio()) / 100.0) * 100;
                 plutAmount += recommendAmount;
                 responseDto.add(new RecommendBudgetResponseDto(ratio.categoryName(), recommendAmount));
             }

--- a/src/main/java/com/finance/budget/service/BudgetService.java
+++ b/src/main/java/com/finance/budget/service/BudgetService.java
@@ -6,10 +6,7 @@ import com.finance.budget.repository.BudgetRepository;
 import com.finance.category.domain.Category;
 import com.finance.budget.dto.ModifyBudgetResponseDto;
 import com.finance.category.repository.CategoryRepository;
-import com.finance.exception.ConflictException;
-import com.finance.exception.ErrorCode;
-import com.finance.exception.ForbiddenException;
-import com.finance.exception.NotFoundException;
+import com.finance.exception.*;
 import com.finance.user.config.TokenProvider;
 import com.finance.user.domain.User;
 import com.finance.user.repository.UserRepository;
@@ -116,6 +113,9 @@ public class BudgetService {
         Long maxAmount = Math.round(requestDto.totalAmount() * 1.2);
         // 입력받은 예산 총액의 ±20% 범위 안에 예산 총액을 설정한 회원들의 기본 카테고리별 예산 평균 비율 조회
         List<BudgetRatioDto> budgetRatioDto = budgetRepository.findBudgetRatioByTotalAmountRange(minAmount, maxAmount);
+        // 추천 받을 예산 총액의 범위에 다른 회원의 예산 총액이 존재하지 않는 경우
+        if(budgetRatioDto.isEmpty())
+            throw new BadRequestException(ErrorCode.CANNOT_RECOMMEND_BUDGET);
         // responseDto
         List<RecommendBudgetResponseDto> responseDto = new ArrayList<>();
         // 기타 항목 계산을 위한 변수

--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
 
     // 예산
     ALREADY_EXIST_BUDGET(HttpStatus.CONFLICT, "해당 카테고리의 예산이 이미 존재합니다."),
-    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예산입니다.");
+    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예산입니다."),
+    CANNOT_RECOMMEND_BUDGET(HttpStatus.BAD_REQUEST, "예산을 추천할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## Issue
- #25 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/budget_recommendation -> dev

## 변경 사항
- 카테고리 별 예산 설정에 어려움이 있는 회원에게 예산 비율을 추천하는 API
- 카테고리 지정 없이 총액을 입력하면 총액의 `±20%` 범위 안에서 예산 총액을 설정한 회원들의 카테고리별 예산의 평균 비율을 계산해 카테고리별로 예산 금액 추천
- 기본 카테고리로만 예산 추천
- 예산의 평균 비율이 5% 미만인 카테고리는 모두 묶어 `기타`로 제공
- 추천 금액은 100원 단위로 반환

## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/budgets/recommendation
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```
- **Request Body**
```
{
    "totalAmount": 2000000
}
```

### Response : 성공시
`200 OK`
```
[
    {
        "categoryName": "식비",
        "amount": 481900
    },
    {
        "categoryName": "주거/통신",
        "amount": 433700
    },
    {
        "categoryName": "카페/간식",
        "amount": 168700
    },
    {
        "categoryName": "쇼핑",
        "amount": 192800
    },
    {
        "categoryName": "문화/여가",
        "amount": 192800
    },
    {
        "categoryName": "생활",
        "amount": 241000
    },
    {
        "categoryName": "금융",
        "amount": 144600
    },
    {
        "categoryName": "기타",
        "amount": 144500
    }
]
```

### Response : 실패시
- 추천 받을 예산 총액의 범위에 다른 회원의 예산 총액이 존재하지 않는 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "예산을 추천할 수 없습니다."
}
```

- 예산 총액을 입력하지 않은 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "예산 총 금액을 입력해주세요."
}
```

- 잘못된 금액을 입력한 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "1원부터 입력 가능합니다."
}
```