### PR TITLE
[feat] 지출 생성 API

### DIFF
--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
     // 예산
     ALREADY_EXIST_BUDGET(HttpStatus.CONFLICT, "해당 카테고리의 예산이 이미 존재합니다."),
     BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예산입니다."),
-    CANNOT_RECOMMEND_BUDGET(HttpStatus.BAD_REQUEST, "예산을 추천할 수 없습니다.");
+    CANNOT_RECOMMEND_BUDGET(HttpStatus.BAD_REQUEST, "예산을 추천할 수 없습니다."),
+
+    // 지출
+    BUDGET_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 카테고리로 설정된 예산이 없어 지출을 생성할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/finance/expense/controller/ExpenseController.java
+++ b/src/main/java/com/finance/expense/controller/ExpenseController.java
@@ -1,13 +1,24 @@
 package com.finance.expense.controller;
 
+import com.finance.expense.dto.CreateExpenseRequestDto;
+import com.finance.expense.dto.CreateExpenseResponseDto;
 import com.finance.expense.service.ExpenseService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/expenses")
 @RequiredArgsConstructor
 public class ExpenseController {
     private final ExpenseService expenseService;
+
+    // 지출 생성
+    @PostMapping
+    public ResponseEntity<CreateExpenseResponseDto> createExpense(@RequestHeader(value = "Authorization") String token, @Valid @RequestBody CreateExpenseRequestDto requestDto) {
+        CreateExpenseResponseDto responseDto = expenseService.createExpense(token, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/expense/controller/ExpenseController.java
+++ b/src/main/java/com/finance/expense/controller/ExpenseController.java
@@ -1,0 +1,13 @@
+package com.finance.expense.controller;
+
+import com.finance.expense.service.ExpenseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/expenses")
+@RequiredArgsConstructor
+public class ExpenseController {
+    private final ExpenseService expenseService;
+}

--- a/src/main/java/com/finance/expense/domain/Expense.java
+++ b/src/main/java/com/finance/expense/domain/Expense.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -32,7 +33,7 @@ public class Expense {
     private String memo;
 
     @Column(nullable = false)
-    private LocalDateTime expensedAt;
+    private LocalDate expensedAt;
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/java/com/finance/expense/domain/Expense.java
+++ b/src/main/java/com/finance/expense/domain/Expense.java
@@ -1,0 +1,56 @@
+package com.finance.expense.domain;
+
+import com.finance.category.domain.Category;
+import com.finance.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "expenses")
+public class Expense {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long expenseId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(nullable = false)
+    @Size(max = 200)
+    private String memo;
+
+    @Column(nullable = false)
+    private LocalDateTime expensedAt;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    @Column(nullable = false)
+    private boolean excludeFromTotal;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+}

--- a/src/main/java/com/finance/expense/dto/CreateExpenseRequestDto.java
+++ b/src/main/java/com/finance/expense/dto/CreateExpenseRequestDto.java
@@ -1,0 +1,14 @@
+package com.finance.expense.dto;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record CreateExpenseRequestDto(
+        @NotNull(message = "카테고리는 필수로 지정해야 합니다.") Long categoryId,
+        @NotNull(message = "지출 금액은 필수로 지정해야 합니다.") @Positive(message = "1원부터 입력 가능합니다.") Long amount,
+        @NotBlank(message = "메모를 입력해주세요.") @Size(max = 200, message = "메모는 200자 이내로 입력해주세요.") String memo,
+        @NotNull(message = "지출 날짜를 입력해주세요.") @PastOrPresent(message = "지출 날짜는 현재 또는 그 이전이어야 합니다.") LocalDate expensedAt,
+        @NotNull(message = "지출 합계 제외 여부를 지정해주세요.") Boolean excludeFromTotal
+) {
+}

--- a/src/main/java/com/finance/expense/dto/CreateExpenseResponseDto.java
+++ b/src/main/java/com/finance/expense/dto/CreateExpenseResponseDto.java
@@ -1,0 +1,9 @@
+package com.finance.expense.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record CreateExpenseResponseDto(
+        String categoryName, Long amount, LocalDate expensedAt, LocalDateTime createdAt, boolean excludeFromTotal
+) {
+}

--- a/src/main/java/com/finance/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/finance/expense/repository/ExpenseRepository.java
@@ -1,0 +1,7 @@
+package com.finance.expense.repository;
+
+import com.finance.expense.domain.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+}

--- a/src/main/java/com/finance/expense/service/ExpenseService.java
+++ b/src/main/java/com/finance/expense/service/ExpenseService.java
@@ -1,0 +1,11 @@
+package com.finance.expense.service;
+
+import com.finance.expense.repository.ExpenseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseService {
+    private final ExpenseRepository expenseRepository;
+}

--- a/src/main/java/com/finance/expense/service/ExpenseService.java
+++ b/src/main/java/com/finance/expense/service/ExpenseService.java
@@ -1,11 +1,62 @@
 package com.finance.expense.service;
 
+import com.finance.budget.repository.BudgetRepository;
+import com.finance.category.domain.Category;
+import com.finance.category.repository.CategoryRepository;
+import com.finance.exception.BadRequestException;
+import com.finance.exception.ErrorCode;
+import com.finance.exception.NotFoundException;
+import com.finance.expense.domain.Expense;
+import com.finance.expense.dto.CreateExpenseRequestDto;
+import com.finance.expense.dto.CreateExpenseResponseDto;
 import com.finance.expense.repository.ExpenseRepository;
+import com.finance.user.config.TokenProvider;
+import com.finance.user.domain.User;
+import com.finance.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ExpenseService {
+    private final BudgetRepository budgetRepository;
+    private final CategoryRepository categoryRepository;
     private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    // 지출 생성
+    @Transactional
+    public CreateExpenseResponseDto createExpense(String token, CreateExpenseRequestDto requestDto) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // categoryId로 category 찾기
+        Category category = categoryRepository.findByCategoryId(requestDto.categoryId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
+        // 해당 카테고리로 설정된 예산이 없을 경우
+        if(budgetRepository.findByCategory_CategoryIdAndUser_UserId(user.getUserId(), requestDto.categoryId()).isEmpty())
+            throw new BadRequestException(ErrorCode.BUDGET_NOT_EXIST);
+        // 지출 생성
+        Expense expense = Expense.builder()
+                .amount(requestDto.amount())
+                .memo(requestDto.memo())
+                .expensedAt(requestDto.expensedAt())
+                .excludeFromTotal(requestDto.excludeFromTotal())
+                .user(user)
+                .category(category)
+                .build();
+        // DB 저장
+        expenseRepository.save(expense);
+        // responseDto 반환
+        return new CreateExpenseResponseDto(category.getCategoryName(), requestDto.amount(), requestDto.expensedAt(), expense.getCreatedAt(), requestDto.excludeFromTotal());
+    }
+
+    // accessToken에서 회원 정보 가져오기
+    public User getUserInfo(String token) {
+        String accessToken = token.split("Bearer ")[1];
+        String account = tokenProvider.getAccount(accessToken);
+        return userRepository.findByAccount(account)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## Issue
- #28 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/create_expense -> dev

## 변경 사항
- 카테고리별로 지출 생성
- 예산이 설정되지 않은 카테고리의 경우 지출 생성 불가
- 지출 날짜는 현재 또는 그 이전 날짜만 입력 가능

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/expenses
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```
- **Request Body**
```
{
    "categoryId": 5,
    "amount": 25000,
    "memo": "신발",
    "expensedAt": "2024-09-22",
    "excludeFromTotal": true
}
```

### Response : 성공시
`201 Created`
```
{
    "categoryName": "식비",
    "amount": 30000,
    "expensedAt": "2024-09-24",
    "createdAt": "2024-09-24T02:42:09.7442689",
    "excludeFromTotal": false
}
```
### Response : 실패시
- 잘못된 `categoryId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 카테고리입니다."
}
```

- 해당 카테고리로 설정된 예산이 없는 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "해당 카테고리로 설정된 예산이 없어 지출을 생성할 수 없습니다."
}
```

- 지출 금액을 입력하지 않은 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "지출 금액은 필수로 지정해야 합니다."
}
```

- 잘못된 금액을 입력한 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "1원부터 입력 가능합니다."
}
```

- 메모를 입력하지 않은 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "메모를 입력해주세요."
}
```

- 메모를 200자 넘게 입력한 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "메모는 200자 이내로 입력해주세요."
}
```

- 지출 날짜를 입력하지 않은 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "지출 날짜를 입력해주세요."
}
```

- 지출 날짜를 현재보다 미래의 날짜로 입력한 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "지출 날짜는 현재 또는 그 이전이어야 합니다."
}
```

- 지출 합계 제외 여부를 지정하지 않은 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "지출 합계 제외 여부를 지정해주세요."
}
```