### PR TITLE
[feat] 지출 상세 조회 API

### DIFF
--- a/src/main/java/com/finance/exception/ErrorCode.java
+++ b/src/main/java/com/finance/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
     CANNOT_RECOMMEND_BUDGET(HttpStatus.BAD_REQUEST, "예산을 추천할 수 없습니다."),
 
     // 지출
-    BUDGET_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 카테고리로 설정된 예산이 없어 지출을 생성할 수 없습니다.");
+    BUDGET_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 카테고리로 설정된 예산이 없어 지출을 생성할 수 없습니다."),
+    EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 지출입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/finance/expense/controller/ExpenseController.java
+++ b/src/main/java/com/finance/expense/controller/ExpenseController.java
@@ -1,10 +1,7 @@
 package com.finance.expense.controller;
 
 import com.finance.expense.domain.Expense;
-import com.finance.expense.dto.CreateExpenseRequestDto;
-import com.finance.expense.dto.CreateExpenseResponseDto;
-import com.finance.expense.dto.ExpenseListResponseDto;
-import com.finance.expense.dto.ExpenseTotalResponseDto;
+import com.finance.expense.dto.*;
 import com.finance.expense.service.ExpenseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +37,12 @@ public class ExpenseController {
     ) {
         ExpenseTotalResponseDto response = expenseService.getExpenseList(token, startAt, endAt, categoryId, minAmount, maxAmount);
         return ResponseEntity.ok().body(response);
+    }
+
+    // 지출 상세 조회
+    @GetMapping("/{expenseId}")
+    public ResponseEntity<ExpenseDetailResponseDto> getExpenseDetail(@PathVariable Long expenseId, @RequestHeader(value = "Authorization") String token) {
+        ExpenseDetailResponseDto responseDto = expenseService.getExpenseDetail(expenseId, token);
+        return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/finance/expense/dto/ExpenseDetailResponseDto.java
+++ b/src/main/java/com/finance/expense/dto/ExpenseDetailResponseDto.java
@@ -1,0 +1,9 @@
+package com.finance.expense.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ExpenseDetailResponseDto(
+        String categoryName, Long amount, String memo, LocalDate expensedAt, LocalDateTime createdAt, LocalDateTime updatedAt, boolean excludeFromTotal
+) {
+}

--- a/src/main/java/com/finance/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/finance/expense/repository/ExpenseRepository.java
@@ -8,9 +8,11 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    // 입력받은 정보에 해당하는 지출 조회
     @Query("SELECT new com.finance.expense.dto.ExpenseListResponseDto(" +
             "c.categoryName, e.amount, e.expensedAt, e.createdAt, e.excludeFromTotal) " +
             "FROM Expense e " +
@@ -28,4 +30,8 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             @Param("minAmount") Long minAmount,
             @Param("maxAmount") Long maxAmount,
             @Param("userId") UUID userId);
+
+    // 지출 식별값으로 지출 조회
+    @Query("SELECT e FROM Expense e WHERE e.expenseId = :expenseId AND e.deletedAt IS NULL")
+    Optional<Expense> findByExpenseId(@Param("expenseId") Long expenseId);
 }


### PR DESCRIPTION
## Issue
- #32 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/expense_detail -> dev

## 변경 사항
- 지출의 상세 정보를 조회하는 API

## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/expenses/:expenseId
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```

### Response : 성공시
`200 OK`
```
{
    "categoryName": "식비",
    "amount": 30000,
    "memo": "떡볶이",
    "expensedAt": "2024-09-24",
    "createdAt": "2024-09-24T02:42:09.744269",
    "updatedAt": "2024-09-24T02:42:09.744269",
    "excludeFromTotal": false
}
```

### Response : 실패시
- 잘못된 `expenseId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 지출입니다."
}
```

- 회원 본인의 지출이 아닌 경우
`403 Forbidden`
```
{
    "status": 403,
    "message": "접근 권한이 없습니다."
}
```