### PR TITLE
[feat] 지출 수정 API

### DIFF
--- a/src/main/java/com/finance/expense/controller/ExpenseController.java
+++ b/src/main/java/com/finance/expense/controller/ExpenseController.java
@@ -45,4 +45,11 @@ public class ExpenseController {
         ExpenseDetailResponseDto responseDto = expenseService.getExpenseDetail(expenseId, token);
         return ResponseEntity.ok().body(responseDto);
     }
+
+    // 지출 수정
+    @PatchMapping("/{expenseId}")
+    public ResponseEntity<ModifyExpenseResponseDto> modifyExpense(@PathVariable Long expenseId, @RequestHeader(value = "Authorization") String token, @Valid @RequestBody ModifyExpenseRequestDto requestDto) {
+        ModifyExpenseResponseDto responseDto = expenseService.modifyExpense(expenseId, token, requestDto);
+        return ResponseEntity.ok().body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/expense/domain/Expense.java
+++ b/src/main/java/com/finance/expense/domain/Expense.java
@@ -54,4 +54,13 @@ public class Expense {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public Expense modifyExpense(Long amount, String memo, LocalDate expensedAt, boolean excludeFromTotal, Category category) {
+        this.amount = amount;
+        this.memo = memo;
+        this.expensedAt = expensedAt;
+        this.excludeFromTotal = excludeFromTotal;
+        this.category = category;
+        return this;
+    }
 }

--- a/src/main/java/com/finance/expense/dto/ModifyExpenseRequestDto.java
+++ b/src/main/java/com/finance/expense/dto/ModifyExpenseRequestDto.java
@@ -1,0 +1,14 @@
+package com.finance.expense.dto;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record ModifyExpenseRequestDto(
+        @NotNull(message = "카테고리는 필수로 지정해야 합니다.") Long categoryId,
+        @NotNull(message = "지출 금액은 필수로 지정해야 합니다.") @Positive(message = "1원부터 입력 가능합니다.") Long amount,
+        @NotBlank(message = "메모를 입력해주세요.") @Size(max = 200, message = "메모는 200자 이내로 입력해주세요.") String memo,
+        @NotNull(message = "지출 날짜를 입력해주세요.") @PastOrPresent(message = "지출 날짜는 현재 또는 그 이전이어야 합니다.") LocalDate expensedAt,
+        @NotNull(message = "지출 합계 제외 여부를 지정해주세요.") Boolean excludeFromTotal
+) {
+}

--- a/src/main/java/com/finance/expense/dto/ModifyExpenseResponseDto.java
+++ b/src/main/java/com/finance/expense/dto/ModifyExpenseResponseDto.java
@@ -1,0 +1,9 @@
+package com.finance.expense.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ModifyExpenseResponseDto(
+        String categoryName, Long amount, LocalDate expensedAt, LocalDateTime createdAt, LocalDateTime updatedAt, boolean excludeFromTotal
+) {
+}

--- a/src/main/java/com/finance/expense/dto/ModifyExpenseResponseDto.java
+++ b/src/main/java/com/finance/expense/dto/ModifyExpenseResponseDto.java
@@ -4,6 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record ModifyExpenseResponseDto(
-        String categoryName, Long amount, LocalDate expensedAt, LocalDateTime createdAt, LocalDateTime updatedAt, boolean excludeFromTotal
+        String categoryName, Long amount, String memo, LocalDate expensedAt, LocalDateTime createdAt, LocalDateTime updatedAt, boolean excludeFromTotal
 ) {
 }


### PR DESCRIPTION
## Issue
- #34 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/modify_expense -> dev

## 변경 사항
- 회원 본인의 지출을 수정하는 API

## 테스트 결과

### Request
```java
HTTP : PATCH
URL: /api/expenses/:expenseId
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```
- **Request Body**
```
{
    "categoryId": 1,
    "amount": 30000,
    "memo": "떡볶이 순대 세트",
    "expensedAt": "2024-09-24",
    "excludeFromTotal": false
}
```

### Response : 성공시
`200 OK`
```
{
    "categoryName": "식비",
    "amount": 30000,
    "memo": "떡볶이 순대 세트",
    "expensedAt": "2024-09-24",
    "createdAt": "2024-09-24T02:42:09.744269",
    "updatedAt": "2024-09-24T20:14:02.303896",
    "excludeFromTotal": false
}
```

### Response : 실패시
- 잘못된 `expenseId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 지출입니다."
}
```

- 회원 본인의 지출이 아닌 경우
`403 Forbidden`
```
{
    "status": 403,
    "message": "접근 권한이 없습니다."
}
```