### PR TITLE
[feat] 지출 삭제 API

### DIFF
--- a/src/main/java/com/finance/expense/controller/ExpenseController.java
+++ b/src/main/java/com/finance/expense/controller/ExpenseController.java
@@ -52,4 +52,11 @@ public class ExpenseController {
         ModifyExpenseResponseDto responseDto = expenseService.modifyExpense(expenseId, token, requestDto);
         return ResponseEntity.ok().body(responseDto);
     }
+
+    // 지출 삭제
+    @DeleteMapping("/{expenseId}")
+    public ResponseEntity<DeleteExpenseResponseDto> deleteExpense(@PathVariable Long expenseId, @RequestHeader(value = "Authorization") String token) {
+        DeleteExpenseResponseDto responseDto = expenseService.deleteExpense(expenseId, token);
+        return ResponseEntity.ok().body(responseDto);
+    }
 }

--- a/src/main/java/com/finance/expense/domain/Expense.java
+++ b/src/main/java/com/finance/expense/domain/Expense.java
@@ -63,4 +63,9 @@ public class Expense {
         this.category = category;
         return this;
     }
+
+    public Expense deleteExpense() {
+        this.deletedAt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/src/main/java/com/finance/expense/dto/DeleteExpenseResponseDto.java
+++ b/src/main/java/com/finance/expense/dto/DeleteExpenseResponseDto.java
@@ -1,0 +1,8 @@
+package com.finance.expense.dto;
+
+import java.time.LocalDateTime;
+
+public record DeleteExpenseResponseDto(
+        String message, LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/com/finance/expense/service/ExpenseService.java
+++ b/src/main/java/com/finance/expense/service/ExpenseService.java
@@ -131,8 +131,8 @@ public class ExpenseService {
                 requestDto.excludeFromTotal(),
                 category
         );
-        // responseDto 변환
-        ModifyExpenseResponseDto responseDto = new ModifyExpenseResponseDto(
+        // responseDto 반환
+        return new ModifyExpenseResponseDto(
                 category.getCategoryName(),
                 requestDto.amount(),
                 requestDto.memo(),
@@ -141,8 +141,23 @@ public class ExpenseService {
                 expense.getUpdatedAt(),
                 requestDto.excludeFromTotal()
         );
+    }
+
+    // 지출 삭제
+    @Transactional
+    public DeleteExpenseResponseDto deleteExpense(Long expenseId, String token) {
+        // accessToken에서 회원 정보 가져오기
+        User user = getUserInfo(token);
+        // expenseId로 expense 찾기
+        Expense expense = expenseRepository.findByExpenseId(expenseId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.EXPENSE_NOT_FOUND));
+        // 회원 본인의 지출이 아닌 경우 삭제 불가
+        if(!user.getUserId().equals(expense.getUser().getUserId()))
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        // 지출 삭제
+        expense.deleteExpense();
         // responseDto 반환
-        return responseDto;
+        return new DeleteExpenseResponseDto("지출을 삭제했습니다.", expense.getDeletedAt());
     }
 
     // accessToken에서 회원 정보 가져오기


### PR DESCRIPTION
## Issue
- #36

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/delete_expense -> dev

## 변경 사항
- 회원 본인의 지출을 삭제하는 API

## 테스트 결과

### Request
```java
HTTP : DELETE
URL: /api/expenses/:expenseId
```
- **Request Header**
```
Authorization: “Bearer XXXXXXXXX”
```

### Response : 성공시
`200 OK`
```
{
    "message": "지출을 삭제했습니다.",
    "deletedAt": "2024-09-24T20:52:30.9181308"
}
```

### Response : 실패시
- 잘못된 `expenseId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "존재하지 않는 지출입니다."
}
```

- 회원 본인의 지출이 아닌 경우
`403 Forbidden`
```
{
    "status": 403,
    "message": "접근 권한이 없습니다."
}
```